### PR TITLE
Feat lightbox item decode

### DIFF
--- a/packages/frosted-ui/src/components/lightbox/lightbox-item.tsx
+++ b/packages/frosted-ui/src/components/lightbox/lightbox-item.tsx
@@ -35,6 +35,15 @@ const itemStateAttributesMapping = {
  *
  * When the item is active, registers its DOM element in context
  * so view transitions can morph to/from it.
+ *
+ * **Image loading tip:** For the smoothest open transition, images inside
+ * the active item should be eagerly loaded so they are decoded before the
+ * View Transition captures the "new" snapshot. If you use Next.js
+ * `<Image>`, set `loading="eager"` (or `priority`/`preload`) on images
+ * rendered inside `Lightbox.Item`. The lightbox waits up to 200ms for
+ * the image to decode before starting the morph; `loading="lazy"` images
+ * that haven't started fetching may miss this window and appear blank
+ * during the opening animation.
  */
 const LightboxItem = React.forwardRef<HTMLDivElement, LightboxItemProps>(
   function LightboxItem(props, forwardedRef) {

--- a/packages/frosted-ui/src/components/lightbox/lightbox-root.tsx
+++ b/packages/frosted-ui/src/components/lightbox/lightbox-root.tsx
@@ -12,8 +12,54 @@ import {
   type NavigationSource,
 } from './lightbox-context';
 
-function startViewTransition(callback: () => void): { finished: Promise<void> } {
-  return (document as Document & { startViewTransition: (cb: () => void) => { finished: Promise<void> } }).startViewTransition(callback);
+function startViewTransition(
+  callback: () => void | Promise<void>,
+): { finished: Promise<void> } {
+  return (
+    document as Document & {
+      startViewTransition: (cb: () => void | Promise<void>) => { finished: Promise<void> };
+    }
+  ).startViewTransition(callback);
+}
+
+const DECODE_MAX_WAIT = 200;
+
+/**
+ * Wait for an image element to decode (pixels composited and ready to paint).
+ * If the image is already complete (e.g. served from cache on a re-open),
+ * resolves immediately with zero delay. Otherwise waits for `decode()` to
+ * finish, bounded by DECODE_MAX_WAIT ms so the transition is never blocked
+ * for too long on slow connections. Resolves immediately for non-image
+ * elements (video, custom HTML).
+ *
+ * Works with plain `<img>` as well as framework image components (e.g.
+ * Next.js `<Image>`) that render a native `<img>` with `srcset`. The
+ * browser's `decode()` resolves for whichever source was selected from
+ * the srcset. For best results, images inside Lightbox.Item should use
+ * `loading="eager"` so the browser starts fetching immediately on mount
+ * rather than waiting for a lazy-load intersection.
+ */
+function waitForImageDecode(target: HTMLElement | null): Promise<void> {
+  if (!target) return Promise.resolve();
+  const img =
+    target.tagName === 'IMG'
+      ? (target as HTMLImageElement)
+      : target.querySelector<HTMLImageElement>('img');
+  if (!img || !('decode' in img)) return Promise.resolve();
+  // Image already loaded (e.g. cached from a previous open) — no wait needed.
+  // The VT API captures the snapshot after this callback resolves, so the
+  // browser will have composited the cached image by then.
+  if (img.complete && img.naturalWidth > 0) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    img.decode().then(settle, settle);
+    setTimeout(settle, DECODE_MAX_WAIT);
+  });
 }
 
 interface LightboxRootProps {
@@ -249,7 +295,7 @@ const LightboxRoot = React.forwardRef<LightboxRootRef, LightboxRootProps>(
               docEl.style.setProperty('--fui-morph-border-radius-from', fromRadius);
             }
 
-            const transition = startViewTransition(() => {
+            const transition = startViewTransition(async () => {
               if (triggerTarget) {
                 triggerTarget.style.viewTransitionName = '';
               }
@@ -262,6 +308,12 @@ const LightboxRoot = React.forwardRef<LightboxRootRef, LightboxRootProps>(
               });
               const itemEl = activeItemElementRef.current;
               const itemTarget = itemEl ? findMorphTarget(itemEl) : null;
+
+              // Wait for the destination image to decode before the browser
+              // captures the "new" snapshot, preventing a flash of empty space
+              // during the morph animation.
+              await waitForImageDecode(itemTarget);
+
               // Read before write to avoid forced reflow
               const toRadius = itemTarget ? getComputedStyle(itemTarget).borderRadius : null;
               if (itemTarget) {

--- a/packages/frosted-ui/src/components/lightbox/lightbox.test.tsx
+++ b/packages/frosted-ui/src/components/lightbox/lightbox.test.tsx
@@ -888,8 +888,11 @@ describe('Lightbox', () => {
         resolveFinished = r;
       });
 
-      const startViewTransition = vi.fn((callback: () => void) => {
-        callback();
+      const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
+        const result = callback();
+        if (result && typeof (result as Promise<void>).then === 'function') {
+          (result as Promise<void>).catch(() => {});
+        }
         return { finished: finishedPromise };
       });
 
@@ -983,8 +986,11 @@ describe('Lightbox', () => {
       let resolveOpen: () => void;
       let resolveClose: () => void;
 
-      const startViewTransition = vi.fn((callback: () => void) => {
-        callback();
+      const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
+        const result = callback();
+        if (result && typeof (result as Promise<void>).then === 'function') {
+          (result as Promise<void>).catch(() => {});
+        }
         if (startViewTransition.mock.calls.length === 1) {
           return { finished: new Promise<void>((r) => { resolveOpen = r; }) };
         }
@@ -1012,8 +1018,11 @@ describe('Lightbox', () => {
       let resolveOpen: () => void;
       let resolveClose: () => void;
 
-      const startViewTransition = vi.fn((callback: () => void) => {
-        callback();
+      const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
+        const result = callback();
+        if (result && typeof (result as Promise<void>).then === 'function') {
+          (result as Promise<void>).catch(() => {});
+        }
         if (startViewTransition.mock.calls.length === 1) {
           return { finished: new Promise<void>((r) => { resolveOpen = r; }) };
         }
@@ -1037,6 +1046,63 @@ describe('Lightbox', () => {
 
       await act(async () => resolveClose!());
       expect(completeSpy).toHaveBeenCalledWith(false);
+    });
+
+    describe('image decode before open transition', () => {
+      it('does not delay open when item has no real image to decode', () => {
+        const { startViewTransition } = mockViewTransitionAPI();
+
+        render(<TestLightbox viewTransition />);
+        fireEvent.click(screen.getByTestId('trigger-0'));
+
+        expect(startViewTransition).toHaveBeenCalledOnce();
+        expect(screen.getByTestId('content')).toBeInTheDocument();
+      });
+
+      it('passes an async callback to startViewTransition on open', () => {
+        const { startViewTransition } = mockViewTransitionAPI();
+
+        render(<TestLightbox viewTransition />);
+        fireEvent.click(screen.getByTestId('trigger-0'));
+
+        expect(startViewTransition).toHaveBeenCalledOnce();
+        const callback = startViewTransition.mock.calls[0][0];
+        expect(callback.constructor.name).toBe('AsyncFunction');
+      });
+
+      it('close VT callback is not async (no decode needed on close)', async () => {
+        const callbacks: Array<() => void | Promise<void>> = [];
+        let resolveOpen: () => void;
+        let resolveClose: () => void;
+        const startViewTransition = vi.fn((cb: () => void | Promise<void>) => {
+          callbacks.push(cb);
+          const result = cb();
+          if (result && typeof (result as Promise<void>).then === 'function') {
+            (result as Promise<void>).catch(() => {});
+          }
+          if (startViewTransition.mock.calls.length === 1) {
+            return { finished: new Promise<void>((r) => { resolveOpen = r; }) };
+          }
+          return { finished: new Promise<void>((r) => { resolveClose = r; }) };
+        });
+        Object.defineProperty(document, 'startViewTransition', {
+          value: startViewTransition,
+          writable: true,
+          configurable: true,
+        });
+
+        render(<TestLightbox viewTransition />);
+        fireEvent.click(screen.getByTestId('trigger-0'));
+        await act(async () => resolveOpen!());
+
+        fireEvent.click(screen.getByTestId('close'));
+
+        expect(callbacks).toHaveLength(2);
+        expect(callbacks[0].constructor.name).toBe('AsyncFunction');
+        expect(callbacks[1].constructor.name).not.toBe('AsyncFunction');
+
+        await act(async () => resolveClose!());
+      });
     });
 
     it('does not use VT when prefers-reduced-motion is set', () => {

--- a/packages/frosted-ui/src/components/lightbox/lightbox.test.tsx
+++ b/packages/frosted-ui/src/components/lightbox/lightbox.test.tsx
@@ -891,7 +891,7 @@ describe('Lightbox', () => {
       const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
         const result = callback();
         if (result && typeof (result as Promise<void>).then === 'function') {
-          (result as Promise<void>).catch(() => {});
+          (result as Promise<void>).catch(vi.fn());
         }
         return { finished: finishedPromise };
       });
@@ -989,7 +989,7 @@ describe('Lightbox', () => {
       const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
         const result = callback();
         if (result && typeof (result as Promise<void>).then === 'function') {
-          (result as Promise<void>).catch(() => {});
+          (result as Promise<void>).catch(vi.fn());
         }
         if (startViewTransition.mock.calls.length === 1) {
           return { finished: new Promise<void>((r) => { resolveOpen = r; }) };
@@ -1021,7 +1021,7 @@ describe('Lightbox', () => {
       const startViewTransition = vi.fn((callback: () => void | Promise<void>) => {
         const result = callback();
         if (result && typeof (result as Promise<void>).then === 'function') {
-          (result as Promise<void>).catch(() => {});
+          (result as Promise<void>).catch(vi.fn());
         }
         if (startViewTransition.mock.calls.length === 1) {
           return { finished: new Promise<void>((r) => { resolveOpen = r; }) };
@@ -1078,7 +1078,7 @@ describe('Lightbox', () => {
           callbacks.push(cb);
           const result = cb();
           if (result && typeof (result as Promise<void>).then === 'function') {
-            (result as Promise<void>).catch(() => {});
+            (result as Promise<void>).catch(vi.fn());
           }
           if (startViewTransition.mock.calls.length === 1) {
             return { finished: new Promise<void>((r) => { resolveOpen = r; }) };


### PR DESCRIPTION
## feat(lightbox): wait for image decode before View Transition

### Summary

- Add `image.decode()` wait inside the View Transition open callback so the browser captures a fully-painted "new" snapshot, preventing a flash of empty/partially-rendered image during the morph animation
- Cached images (e.g. second open) resolve instantly with zero delay; uncached images wait up to 200ms max
- Close transitions are unaffected (image is already visible, no decode needed)
- Add JSDoc guidance for consumers using Next.js `<Image>` or other framework image components with `loading="lazy"`

### Problem

When the lightbox opens with View Transitions, the browser captures old (trigger) and new (lightbox item) snapshots and morphs between them. If the lightbox item's image hasn't finished loading/decoding when the snapshot is captured, the morph animates from the trigger into an empty rectangle — then the image pops in after the animation completes. This is most noticeable on first open with uncached images, slow connections, or large images.

### Solution

Inspired by [PhotoSwipe's `image.decode()` strategy](https://github.com/dimsemenov/PhotoSwipe/blob/master/src/js/opener.js), the open VT callback is now `async`. After React mounts the lightbox via `flushSync`, but before the browser captures the "new" snapshot, we await `waitForImageDecode(itemTarget)`:

- **Cached/complete images**: `img.complete && img.naturalWidth > 0` — resolves immediately, zero added latency
- **Loading images**: races `img.decode()` against a 200ms timeout — whichever finishes first wins
- **Non-image content** (video, custom HTML, no img found): resolves immediately
- **Framework components** (Next.js `<Image>`): works transparently since they render a native `<img>` with `srcset`; `decode()` resolves for whichever source the browser selected

The View Transitions API supports async callbacks — the browser waits for the returned promise to settle before capturing the new state snapshot, so this integrates cleanly without any hacks.

### Changes

| File | Change |
|---|---|
| `lightbox-root.tsx` | Add `waitForImageDecode()` helper; update `startViewTransition` types to accept async callbacks; make open VT callback async with decode await |
| `lightbox-item.tsx` | Add JSDoc tip about `loading="eager"` for framework image components |
| `lightbox.test.tsx` | Update VT mocks to handle async callbacks; add 3 new decode-specific tests |

### Test plan

- [x] All 127 lightbox tests pass (124 existing + 3 new)
- [ ] Manual: open lightbox with uncached image on throttled network — morph should show image, not empty rect
- [ ] Manual: open/close/reopen same item — second open should have zero decode delay
- [ ] Manual: verify non-image items (video, custom HTML) open with no added delay
