### PR TITLE
chore(frosted-ui): upgrade @base-ui/react to 1.7.0

### DIFF
--- a/packages/frosted-ui/package.json
+++ b/packages/frosted-ui/package.json
@@ -69,7 +69,7 @@
     "release": "turbo-module publish"
   },
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@internationalized/date": "^3.5.6",
     "@react-aria/calendar": "^3.5.13",
     "@react-aria/datepicker": "^3.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: link:packages/eslint-config-custom
       prettier:
         specifier: latest
-        version: 3.8.3
+        version: 3.9.6
       turbo:
         specifier: 1.12.5
         version: 1.12.5
@@ -82,7 +82,7 @@ importers:
         version: 8.8.0(eslint@7.32.0)
       eslint-config-turbo:
         specifier: latest
-        version: 2.9.14(eslint@7.32.0)(turbo@1.12.5)
+        version: 2.10.8(eslint@7.32.0)(turbo@1.12.5)
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.50.0
@@ -112,8 +112,8 @@ importers:
   packages/frosted-ui:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@internationalized/date':
         specifier: ^3.5.6
         version: 3.5.6
@@ -158,7 +158,7 @@ importers:
         version: 2.8.0
       vaul-base:
         specifier: ^1.0.0
-        version: 1.0.0(@base-ui/react@1.6.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.0(@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@frosted-ui/colors':
         specifier: workspace:*
@@ -171,31 +171,31 @@ importers:
         version: 0.1.82
       '@storybook/addon-essentials':
         specifier: ^8.5.3
-        version: 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.9.6))
       '@storybook/addon-interactions':
         specifier: ^8.5.3
-        version: 8.6.14(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@storybook/addon-links':
         specifier: ^8.5.3
-        version: 8.6.14(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))
       '@storybook/addon-mdx-gfm':
         specifier: ^8.5.3
-        version: 8.6.14(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@storybook/addon-onboarding':
         specifier: ^8.5.3
-        version: 8.6.14(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@storybook/blocks':
         specifier: ^8.5.3
-        version: 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))
       '@storybook/react':
         specifier: ^8.5.3
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))(typescript@5.6.3)
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))(typescript@5.6.3)
       '@storybook/react-vite':
         specifier: ^8.5.3
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.59.0)(storybook@8.6.14(prettier@3.8.3))(typescript@5.6.3)(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.59.0)(storybook@8.6.14(prettier@3.9.6))(typescript@5.6.3)(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
       '@storybook/test':
         specifier: ^8.5.3
-        version: 8.6.14(storybook@8.6.14(prettier@3.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@tanstack/react-form':
         specifier: ^0.43.0
         version: 0.43.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.6.3)
@@ -282,7 +282,7 @@ importers:
         version: 7.71.1(react@19.1.0)
       storybook:
         specifier: ^8.5.3
-        version: 8.6.14(prettier@3.8.3)
+        version: 8.6.14(prettier@3.9.6)
       stylelint:
         specifier: ^15.11.0
         version: 15.11.0(typescript@5.6.3)
@@ -1171,8 +1171,8 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -1188,8 +1188,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': 19.1.10
       react: ^17 || ^18 || ^19
@@ -1902,8 +1902,14 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
@@ -1911,8 +1917,17 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@formatjs/ecma402-abstract@2.2.0':
     resolution: {integrity: sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==}
@@ -4685,6 +4700,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urql/core@5.2.0':
     resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
@@ -5965,8 +5981,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-turbo@2.9.14:
-    resolution: {integrity: sha512-8bAXNDwtmHV7CuSDX+FB9+TslZEP8qJoNWY9FQTEhyO42bRimcExxwOh1+K2H2JV2VFXJrkt1KxyJmy2xm8Ukw==}
+  eslint-config-turbo@2.10.8:
+    resolution: {integrity: sha512-3i+j04OCtWevLFmnbsj4Nxv3YmHGlk8c6eL83xNH4Arvbfl09ct/9ZIElAT+gi8TcZBdYnhRXj8aB7prMy1XuA==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5977,8 +5993,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
-  eslint-plugin-turbo@2.9.14:
-    resolution: {integrity: sha512-ROTlsO1JBJLATxtDNd7t22vviSb0hD8fKnjOO0WRgtxJW3VBRNO3BLAC129GPZSvEvtMH/f71Y2TzrqGPjLpEw==}
+  eslint-plugin-turbo@2.10.8:
+    resolution: {integrity: sha512-D6/FZUlP5IkZl/Wahoyi9q/UYFnyuh0cyqf3x5aHJNTmlu+bC6+h03cNPzPoQS7708ts54KYreUZW+FdRG5BWg==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -8360,8 +8376,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -10895,22 +10911,22 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.6.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.3.1(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@floating-ui/utils': 0.2.11
+      '@base-ui/utils': 0.3.2(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@floating-ui/utils': 0.2.12
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.10
 
-  '@base-ui/utils@0.3.1(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@base-ui/utils@0.3.2(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       reselect: 5.2.0
@@ -11558,10 +11574,19 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
   '@floating-ui/react-dom@2.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -11569,7 +11594,15 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  '@floating-ui/react-dom@2.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@formatjs/ecma402-abstract@2.2.0':
     dependencies:
@@ -14467,150 +14500,150 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-actions@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-backgrounds@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-controls@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-docs@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.1.10)(react@19.2.0)
-      '@storybook/blocks': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/blocks': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.9.6))
       react: 19.2.0
       react-dom: 19.1.0(react@19.2.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
       - webpack-sources
 
-  '@storybook/addon-essentials@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-essentials@8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-docs': 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      storybook: 8.6.14(prettier@3.8.3)
+      '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.1.10)(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-toolbars': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/addon-viewport': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
       - webpack-sources
 
-  '@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-highlight@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/addon-interactions@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-interactions@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       polished: 4.3.1
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.6.14(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-links@8.6.14(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.1.0
 
-  '@storybook/addon-mdx-gfm@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-mdx-gfm@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       remark-gfm: 4.0.0
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-measure@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-onboarding@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-onboarding@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-outline@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-toolbars@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/addon-viewport@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/blocks@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/blocks@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/icons': 1.2.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/blocks@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/blocks@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/icons': 1.2.12(react-dom@19.1.0(react@19.1.0))(react@19.2.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.8.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.9.6))(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       browser-assert: 1.2.1
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
     transitivePeerDependencies:
       - webpack-sources
 
-  '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/core@8.6.14(prettier@3.8.3)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/core@8.6.14(prettier@3.9.6)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.24.2
@@ -14622,16 +14655,16 @@ snapshots:
       util: 0.12.5
       ws: 8.18.0
     optionalDependencies:
-      prettier: 3.8.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - bufferutil
       - storybook
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/csf-plugin@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       unplugin: 1.14.1
     transitivePeerDependencies:
       - webpack-sources
@@ -14648,84 +14681,84 @@ snapshots:
       react: 19.2.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/instrumenter@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.3
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/manager-api@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/preview-api@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.2.0)(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       react: 19.2.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.59.0)(storybook@8.6.14(prettier@3.8.3))(typescript@5.6.3)(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
+  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.59.0)(storybook@8.6.14(prettier@3.9.6))(typescript@5.6.3)(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.6.3)(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
       '@rollup/pluginutils': 5.1.2(rollup@4.59.0)
-      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.8.3))(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
-      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))(typescript@5.6.3)
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.9.6))(vite@7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2))
+      '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))(typescript@5.6.3)
       find-up: 5.0.0
       magic-string: 0.30.12
       react: 19.1.0
       react-docgen: 7.1.0
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.8
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@22.19.1)(jiti@2.4.2)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.2)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.9.6))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
       - webpack-sources
 
-  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))(typescript@5.6.3)':
+  '@storybook/react@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6)))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))(typescript@5.6.3)':
     dependencies:
-      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.8.3))
-      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/manager-api': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/preview-api': 8.6.14(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.14(prettier@3.9.6))
+      '@storybook/theming': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
     optionalDependencies:
-      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       typescript: 5.6.3
 
-  '@storybook/test@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/test@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/instrumenter': 8.6.14(storybook@8.6.14(prettier@3.9.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
-  '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.8.3))':
+  '@storybook/theming@8.6.14(storybook@8.6.14(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.14(prettier@3.8.3)
+      storybook: 8.6.14(prettier@3.9.6)
 
   '@swc/helpers@0.5.13':
     dependencies:
@@ -16671,17 +16704,17 @@ snapshots:
     dependencies:
       eslint: 7.32.0
 
-  eslint-config-turbo@2.9.14(eslint@7.32.0)(turbo@1.12.5):
+  eslint-config-turbo@2.10.8(eslint@7.32.0)(turbo@1.12.5):
     dependencies:
       eslint: 7.32.0
-      eslint-plugin-turbo: 2.9.14(eslint@7.32.0)(turbo@1.12.5)
+      eslint-plugin-turbo: 2.10.8(eslint@7.32.0)(turbo@1.12.5)
       turbo: 1.12.5
 
   eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-turbo@2.9.14(eslint@7.32.0)(turbo@1.12.5):
+  eslint-plugin-turbo@2.10.8(eslint@7.32.0)(turbo@1.12.5):
     dependencies:
       dotenv: 16.0.3
       eslint: 7.32.0
@@ -19637,7 +19670,7 @@ snapshots:
 
   prettier@3.7.4: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.6: {}
 
   pretty-bytes@5.2.0: {}
 
@@ -20655,11 +20688,11 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@8.6.14(prettier@3.8.3):
+  storybook@8.6.14(prettier@3.9.6):
     dependencies:
-      '@storybook/core': 8.6.14(prettier@3.8.3)(storybook@8.6.14(prettier@3.8.3))
+      '@storybook/core': 8.6.14(prettier@3.9.6)(storybook@8.6.14(prettier@3.9.6))
     optionalDependencies:
-      prettier: 3.8.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -21385,9 +21418,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul-base@1.0.0(@base-ui/react@1.6.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  vaul-base@1.0.0(@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@base-ui/react': 1.6.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@base-ui/react': 1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `@base-ui/react` from `^1.6.0` → `^1.7.0` (latest as of Aug 4, 2026).

No Frosted UI source changes were required. Validated locally:
- `tsc` (CJS + ESM) ✅
- `eslint` + `stylelint` ✅
- `vitest` — 312/312 tests passing ✅

Sources: [Base UI v1.7.0 release notes](https://base-ui.com/react/overview/releases/v1-7-0), [GitHub release](https://github.com/mui/base-ui/releases/tag/v1.7.0), [CHANGELOG](https://github.com/mui/base-ui/blob/master/CHANGELOG.md).

---

## Breaking changes

**Official changelog marks no 🚨 breaking changes in v1.7.0.**

However, there are behavioral, API, and type changes consumers (and Frosted UI wrappers) should be aware of:

### Behavioral / DOM changes (potentially breaking in practice)

1. **`Accordion.Root` no longer sets an implicit `dir` attribute** ([#5117](https://github.com/mui/base-ui/pull/5117))
   - Previously `Accordion.Root` wrote `dir` onto the root. Direction now comes from the document / ancestor only.
   - Impact: CSS/JS that depended on `Accordion.Root[dir]` may stop matching. Pass `dir` explicitly if needed.

2. **`Combobox.Input` / `Autocomplete.Input` no longer inject `type="text"`** ([#5104](https://github.com/mui/base-ui/pull/5104))
   - Native `<input>` still defaults to text, but the attribute is no longer present in the DOM.
   - Impact: selectors like `input[type="text"]` will no longer match unless `type="text"` is passed explicitly.

3. **Listbox separators use `role="presentation"`** ([#5399](https://github.com/mui/base-ui/pull/5399))
   - `Select.Separator`, `Combobox.Separator`, and `Autocomplete.Separator` no longer expose `role="separator"` (axe/ARC compliance).
   - `Select.Separator` switched from a re-export of the generic `Separator` to a dedicated listbox separator component.
   - Public props (`orientation`, etc.) are preserved.

4. **Checkbox Group / Radio Group form values aligned with native submission** ([#5218](https://github.com/mui/base-ui/pull/5218), [#5238](https://github.com/mui/base-ui/pull/5238))
   - Form payload shape may change vs prior Base UI behavior. Verify any custom form serialization that assumed the old values.

5. **Popup / overlay remount + handle reuse**
   - Dialog, Alert Dialog, Drawer, Menu, Popover, Preview Card, Tooltip no longer reopen after remounting with a reused handle ([#5109](https://github.com/mui/base-ui/pull/5109), [#5149](https://github.com/mui/base-ui/pull/5149)).

6. **Disabled state inheritance**
   - `Combobox.Item` / `Select.Item` inherit disabled from Root ([#5365](https://github.com/mui/base-ui/pull/5365)).
   - `Menu` propagates disabled state to items ([#5363](https://github.com/mui/base-ui/pull/5363)).

7. **`Field` keeps invalid state when disabled** ([#5116](https://github.com/mui/base-ui/pull/5116)).

8. **`Select` no longer force-mounts the popup on programmatic value changes** ([#5119](https://github.com/mui/base-ui/pull/5119)).

### API additions / changes

| Area | Change |
|---|---|
| Autocomplete / Combobox | New `ChangeEventReason` values: `"input-press"`, `"cancel-open"` ([#5356](https://github.com/mui/base-ui/pull/5356), [#5376](https://github.com/mui/base-ui/pull/5376)) |
| Autocomplete | New `form?: string` prop on Root (associates the internal input with an external form) |
| Combobox | Exposes `aria-expanded` / expanded behavior for inline comboboxes ([#5332](https://github.com/mui/base-ui/pull/5332)) |
| Combobox / Autocomplete | New `.Separator` part |
| Select | Dedicated `.Separator` part (listbox-safe semantics) |
| Toast | `render` prop content now works on `Toast.Title`, `Toast.Description`, `Toast.Action` ([#5210](https://github.com/mui/base-ui/pull/5210)) |
| Modal docs | Touch-device modal scroll behavior clarified for Combobox / Select |

### Type changes

1. **`render` callback props specialized to the rendered element** ([#5104](https://github.com/mui/base-ui/pull/5104))
   - Third generic of `BaseUIComponentProps` now types callback props as the intrinsic element for:
     - `Avatar.Image` → `'img'`
     - `Form` → `'form'`
     - `NumberField.Input` / `OTPField.Input` → `'input'`
     - `PreviewCard.Trigger` / `Menu.LinkItem` / `NavigationMenu.Link` / `Toolbar.Link` → `'a'`
   - Polymorphic parts (e.g. `Combobox.Input`, `Field.Control`, button parts via `nativeButton`) remain loosely typed as `HTMLProps`.
   - May surface new TS errors if a `render` callback assumed looser props (or the reverse: more precise props like `src`/`href` are now available).

2. **Implementation-only types stripped from published `.d.ts`** ([#5165](https://github.com/mui/base-ui/pull/5165))
   - `@internal` declarations are no longer emitted.
   - Deep imports of internals (e.g. previously published helpers like `FloatingFocusManager`, `useAnchorPositioning`, numeral utils, store helpers) will fail typechecking if used.
   - Frosted UI does not depend on these internals.

3. **`AutocompleteRootChangeEventReason` / `ComboboxRootChangeEventReason` union widened**
   - Adds `"input-press"` and `"cancel-open"`. Exhaustive `switch`/`if` chains over reasons may need updates.

4. **Internal path moves** (only relevant for deep imports)
   - e.g. `useAnchorPositioning` moved under `internals/`; several utils relocated/removed from the public declaration graph.

### Frosted UI impact assessment

| Concern | Status |
|---|---|
| Compile / typecheck against 1.7.0 | Passes with no source edits |
| Existing `DialogRootActions` / `AlertDialogRootActions` imports | Still exported |
| `useRender` / `mergeProps` | Unchanged public surface |
| Autocomplete `keepHighlight` stories | Still valid (Autocomplete retains the prop; Combobox had removed it earlier in 1.6) |
| Select.Separator wrapper | Compatible; benefits from a11y role fix automatically |

---

## What's new in `@base-ui/react@1.7.0`

### Features / enhancements
- Typed `render` callback props based on the rendered element
- Autocomplete locale-aware filtering
- Autocomplete `form` prop for associating an external form
- New Combobox / Autocomplete / Select listbox `Separator` parts (presentation role)
- Combobox inline `aria-expanded` exposure
- New open-change reasons: `input-press`, `cancel-open`
- Scroll Area WebKit overscroll feedback on Thumb
- Avatar Fallback shows immediately when `delay={0}`
- Toast `render` prop support on Title / Description / Action

### Fixes (high level)
- Popup positioning: collision padding off-by-one, unwanted flip with capped scrollable content, left-anchored auto-resize origin, unpositioned popups at viewport origin, canceled-exit unmount completion
- Focus restoration after keyboard close in Safari/Firefox
- Dialog touch outside-press without backdrop; scroll-lock handoff with external overlays
- Drawer swipe/open reliability, iOS cross-axis scroll, Shadow DOM gestures, virtual keyboard scroll
- Menu/submenu: duplicate `onOpenChange`, VoiceOver, TalkBack, pinch-zoom, Chrome mouseleave
- Combobox/Select highlight/filter/scroll fixes (Safari hover highlight, grouped limit, query clear, disabled inheritance)
- Field `data-dirty` for null-valued controls; Form focuses first invalid field in document order
- Number Field multi-character format symbol editing
- Progress custom `min`/`max` semantics
- Slider assorted fixes; Tabs Suspense pre-hydration indicator
- Toast timer / swipe / re-add / provider effect ordering
- Navigation Menu frozen state when open trigger unmounts
- Radio unnecessary ARIA attributes removed; internal input clicks no longer bubble (Checkbox/Switch/Radio)

### Performance / bundle size
Across many components Base UI reduced parsed bundle size and avoided redundant work:
- Shared popup / store / dialog / popover / field / form / meter / progress / scroll-area / slider / switch / tabs / toast / toolbar / toggle-group size reductions
- Avoid redundant re-renders during lazy flipping
- Remove redundant lifecycle synchronization
- Exclude prehydration scripts from client bundles (Slider, Tabs)
- Deduplicate Combobox/Select/Autocomplete handlers and swipe math

---

## Full v1.7.0 changelog (from upstream)

### General
- Restore visible focus after keyboard close in Safari and Firefox (#5093)
- Type `render` callback props based on the rendered element (#5104)
- Reduce popup / store / shared popup bundle size (#5233, #5250, #5192)
- Keep unpositioned popups at the viewport origin (#5299)
- Correct layout and passive effect timing (#5337)
- Remove redundant lifecycle synchronization (#5341)
- Prevent stale cleanup from clearing registered part IDs (#5340)
- Complete popup unmounting after a canceled exit transition (#5401)
- Fix rendered trigger ID ownership (#5110)
- Prevent unwanted flip with capped scrollable content (#5120)
- Fix `collisionPadding` off-by-one on the biased side (#5143)
- Mount popup subtrees synchronously when opening in React 17 (#5309)
- Fix auto-resize origin for left-anchored popups (#5370)
- Avoid redundant re-renders during lazy flipping (#5372)
- Strip implementation-only types from published `.d.ts` files (#5165)
- Fix `usePreviousValue` equality comparison (#5264)

### Components
- **Accordion:** Remove implicit `dir` on Root (#5117)
- **Alert Dialog / Dialog / Drawer / Menu / Popover / Preview Card / Tooltip:** Prevent reopen after remount with reused handle (#5109, #5149)
- **Autocomplete:** Locale filtering; `input-press` / `cancel-open` reasons; reset scroll on filter; separator semantics
- **Avatar:** Fallback immediate at `delay={0}`
- **Button:** Keyboard click for custom elements
- **Checkbox / Checkbox Group / Switch / Radio Group:** Click bubbling, validation, native form values, bundle size
- **Combobox:** Filtering/highlight fixes; `expanded` for inline; disabled inheritance; separator; portalled content; bundle cleanup
- **Composite:** Nested reorder, disabled nav skip, RTL scroll alignment
- **Drawer:** Swipe/open, iOS scroll, Shadow DOM, snap points, bundle
- **Field / Fieldset / Form:** Invalid-when-disabled, `data-dirty`, focus first invalid, bundle
- **Menu:** Pinch-zoom, submenu hover/VO/TalkBack, disabled propagation, exit animation
- **Meter / Progress / Toggle Group:** Formatting / min-max / bundle
- **Navigation Menu:** Frozen menu on trigger unmount; pinch-zoom
- **Number Field / OTP Field:** Format symbols; invalid autofocus when autoSubmit blocked
- **Scroll Area:** Thumb drag, iOS visibility, overscroll feedback, snap while dragging
- **Select:** Highlight/disabled/mount/separator fixes
- **Slider / Tabs:** Assorted fixes; Suspense indicator; exclude prehydration from client bundles
- **Toast:** Timer, swipe locking, re-add closing toast, `render` prop content, provider effect order

---

## Test plan

- [x] Bump `@base-ui/react` to `^1.7.0` and refresh lockfile
- [x] `pnpm --filter=frosted-ui exec tsc --project tsconfig-esm.json --noEmit`
- [x] `pnpm --filter=frosted-ui build:js` (CJS + ESM)
- [x] `pnpm --filter=frosted-ui lint`
- [x] `pnpm --filter=frosted-ui test` (312 tests)
- [ ] CI green on this PR
- [ ] Spot-check Storybook surfaces that wrap Base UI heavily (Combobox, Select, Dialog, Menu, Toast, Accordion) if desired before merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b799cb20-62b5-4aad-9033-e9e7a838d771?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b799cb20-62b5-4aad-9033-e9e7a838d771&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

