### PR TITLE
fix(scroll-area): show all communities in vertical rails

### DIFF
--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.css
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.css
@@ -15,11 +15,22 @@
   overflow: hidden;
   width: 100%;
   height: 100%;
+  /*
+   * Allow the scroll area to shrink inside flex layouts (e.g. a vertical
+   * communities rail). Without this, flex items default to min-height/width:
+   * auto and grow to fit content, so ancestors clip the overflow and the
+   * viewport never becomes scrollable.
+   */
+  min-height: 0;
+  min-width: 0;
 }
 
 .fui-ScrollAreaViewport {
   width: 100%;
   height: 100%;
+  flex: 1 1 0%;
+  min-height: 0;
+  min-width: 0;
 
   /* Stop Chrome back/forward two-finger swipe */
   overscroll-behavior-x: contain;

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,7 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Button, Code, Heading, IconButton, ScrollArea, Text, TextField, scrollAreaPropDefs } from '..';
+import {
+  Avatar,
+  Button,
+  Code,
+  Heading,
+  IconButton,
+  ScrollArea,
+  Text,
+  TextField,
+  scrollAreaPropDefs,
+} from '..';
 
 const meta = {
   title: 'Components/ScrollArea',
@@ -466,6 +476,65 @@ export const ScrollableElementRef: Story = {
           <Button variant="soft" size="1" onClick={() => scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })}>
             Scroll to Top
           </Button>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Simulates the Whop communities rail: a fixed-height flex column where the
+ * ScrollArea is a flex:1 child between chrome above/below. With many items,
+ * every community must remain reachable via scrolling (not clipped by the
+ * flex parent).
+ */
+export const VerticalRail: Story = {
+  args: {
+    scrollbars: 'vertical',
+    type: 'hover',
+  },
+  render: (args) => {
+    const communities = Array.from({ length: 40 }, (_, i) => ({
+      id: i + 1,
+      color: (['indigo', 'cyan', 'orange', 'crimson', 'green', 'violet'] as const)[i % 6],
+    }));
+
+    return (
+      <div
+        style={{
+          width: 72,
+          height: 420,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--space-2)',
+          padding: 'var(--space-2)',
+          border: '1px solid var(--color-stroke)',
+          borderRadius: 'var(--radius-3)',
+          background: 'var(--color-panel)',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'center', flexShrink: 0 }}>
+          <Avatar size="3" fallback="W" color="gray" highContrast />
+        </div>
+
+        <ScrollArea {...args} style={{ flex: 1 }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+              paddingBlock: 'var(--space-1)',
+            }}
+          >
+            {communities.map((community) => (
+              <Avatar key={community.id} size="3" fallback={String(community.id)} color={community.color} />
+            ))}
+          </div>
+        </ScrollArea>
+
+        <div style={{ display: 'flex', justifyContent: 'center', flexShrink: 0 }}>
+          <Avatar size="3" fallback="+" color="gray" />
         </div>
       </div>
     );

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.test.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ScrollArea } from './scroll-area';
+
+function getContentElement(container: HTMLElement) {
+  return container.querySelector('.fui-ScrollAreaViewport > [role="presentation"]') as HTMLElement | null;
+}
+
+describe('ScrollArea', () => {
+  it('renders root/viewport classes used for flex-rail overflow fixes', () => {
+    const { container } = render(
+      <ScrollArea scrollbars="vertical" style={{ flex: 1 }}>
+        <div style={{ height: 1200 }}>Tall content</div>
+      </ScrollArea>,
+    );
+
+    expect(container.querySelector('.fui-ScrollAreaRoot')).toBeTruthy();
+    expect(container.querySelector('.fui-ScrollAreaViewport')).toBeTruthy();
+  });
+
+  it('overrides Base UI Content minWidth for vertical scrolling', () => {
+    const { container } = render(
+      <ScrollArea scrollbars="vertical" style={{ height: 100, width: 100 }}>
+        <div style={{ height: 300 }}>Tall</div>
+      </ScrollArea>,
+    );
+
+    const content = getContentElement(container);
+    expect(content).toBeTruthy();
+    expect(content?.style.minWidth).toBe('0px');
+    expect(content?.style.width).toBe('100%');
+  });
+
+  it('overrides Base UI Content minWidth when scrollbars is both (default)', () => {
+    const { container } = render(
+      <ScrollArea scrollbars="both" style={{ height: 100, width: 100 }}>
+        <div style={{ height: 300, width: 300 }}>Tall and wide</div>
+      </ScrollArea>,
+    );
+
+    const content = getContentElement(container);
+    expect(content).toBeTruthy();
+    expect(content?.style.minWidth).toBe('0px');
+    expect(content?.style.width).toBe('100%');
+  });
+
+  it('keeps Base UI Content minWidth fit-content for horizontal-only scrolling', () => {
+    const { container } = render(
+      <ScrollArea scrollbars="horizontal" style={{ height: 100, width: 100 }}>
+        <div style={{ width: 300 }}>Wide</div>
+      </ScrollArea>,
+    );
+
+    const content = getContentElement(container);
+    expect(content).toBeTruthy();
+    // Frosted does not override; Base UI's default remains.
+    expect(content?.style.minWidth).not.toBe('0px');
+    expect(content?.style.width).not.toBe('100%');
+  });
+});

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -53,7 +53,13 @@ function ScrollArea(props: ScrollAreaProps) {
         // See: https://developer.chrome.com/blog/keyboard-focusable-scrollers
         tabIndex={undefined}
       >
-        <ScrollAreaPrimitive.Content style={scrollbars === 'vertical' ? { minWidth: 0, width: '100%' } : undefined}>
+        <ScrollAreaPrimitive.Content
+          // Base UI Content defaults to minWidth: fit-content, which is needed
+          // for horizontal scrolling. For any orientation that scrolls vertically
+          // (including the default "both"), override so tall column layouts
+          // (e.g. the communities rail) size and scroll correctly.
+          style={scrollbars !== 'horizontal' ? { minWidth: 0, width: '100%' } : undefined}
+        >
           {children}
         </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users with many communities reported that the Whop communities rail did not show all of them. The rail uses Frosted `ScrollArea` as a `flex: 1` child inside a fixed-height column. Flex items default to `min-height: auto`, so the scroll area grew to the full community list height, an ancestor clipped the overflow, and the viewport never became scrollable.

## Changes

- Set `min-height: 0` / `min-width: 0` on `ScrollArea` root so it can shrink in flex layouts
- Make the viewport a flex child (`flex: 1 1 0%`) with matching min size so it owns the constrained height
- Apply the Content `minWidth: 0` override for both `vertical` and default `both` scrollbar modes (not only `vertical`)
- Add a `VerticalRail` Storybook story that mirrors the communities rail
- Add unit tests for the Content style overrides

## Test plan

- [x] `pnpm --filter=frosted-ui test -- src/components/scroll-area/scroll-area.test.tsx`
- [x] `pnpm --filter=frosted-ui lint:js`
- [x] `pnpm --filter=frosted-ui lint:css`
- [ ] Storybook: open `Components/ScrollArea` → `VerticalRail` and confirm all 40 avatars are reachable by scrolling
- [ ] In the Whop communities view with a large membership list, confirm every community is reachable in the rail

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5e9889e-22c3-4b5f-aef0-b33f09ed9b2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5e9889e-22c3-4b5f-aef0-b33f09ed9b2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

