### PR TITLE
fix(scroll-area): hardcoded overscroll-behavior-x: none

### DIFF
--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.css
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.css
@@ -21,9 +21,6 @@
   width: 100%;
   height: 100%;
 
-  /* Stop Chrome back/forward two-finger swipe */
-  overscroll-behavior-x: contain;
-
   &:where(:focus-visible) {
     outline: 2px solid var(--color-focus-root);
     outline-offset: -2px;


### PR DESCRIPTION
There was redundant `overscroll-behavior-x: none` on the scroll area which prevented the native swipe to go back/forward on macos. remove it