### PR TITLE
perf: stop shipping the tooltip module and emoji color map to every consumer

### DIFF
--- a/apps/tailwind/app/main/page.tsx
+++ b/apps/tailwind/app/main/page.tsx
@@ -13,8 +13,8 @@ import {
   Theme,
   ThemePanel,
   Tooltip,
-  getColorForEmoji,
 } from 'frosted-ui';
+import { getColorForEmoji } from 'frosted-ui/helpers/emoji-colors';
 import localFont from 'next/font/local';
 import WhopLogo from './WhopLogo';
 

--- a/packages/frosted-ui/.storybook/preview.tsx
+++ b/packages/frosted-ui/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Decorator, Preview } from '@storybook/react';
 import React from 'react';
 import { Toaster } from '../src/components/toast';
+import { Tooltip } from '../src/components/tooltip';
 import { Theme } from '../src/theme';
 import '../styles.css';
 
@@ -23,11 +24,16 @@ export const withTheme: Decorator = (Story, context) => {
 }
 `}
       </style>
-      <Theme accentColor="blue" grayColor={'gray'} appearance={theme}>
-        <Story />
-        <Toaster />
-        {/* <ThemePanel /> */}
-      </Theme>
+      {/* Mirrors the recommended app setup: `Tooltip.Provider` mounted once at
+          the root so adjacent tooltips share a delay group. It is opt-in so that
+          apps which never render a tooltip don't pay for the module. */}
+      <Tooltip.Provider>
+        <Theme accentColor="blue" grayColor={'gray'} appearance={theme}>
+          <Story />
+          <Toaster />
+          {/* <ThemePanel /> */}
+        </Theme>
+      </Tooltip.Provider>
     </>
   );
 };

--- a/packages/frosted-ui/README.md
+++ b/packages/frosted-ui/README.md
@@ -45,6 +45,20 @@ export default function () {
 }
 ```
 
+If your app uses `Tooltip`, also mount `Tooltip.Provider` at the root. It puts every tooltip in a shared delay group, so moving from one trigger to an adjacent one opens the tooltip instantly instead of waiting out the delay again:
+
+```tsx
+import { Theme, Tooltip } from 'frosted-ui';
+
+<Tooltip.Provider>
+  <Theme>
+    <MyApp />
+  </Theme>
+</Tooltip.Provider>;
+```
+
+This is deliberately opt-in rather than built into `Theme`: the provider is only reachable through a Base UI namespace export that bundlers cannot tree-shake, so mounting it unconditionally would add ~34 kB gzipped to apps that never render a tooltip.
+
 ## Guides
 
 - [Setup steps](https://storybook.whop.dev/?path=/docs/guides-1-getting-started--docs)

--- a/packages/frosted-ui/README.md
+++ b/packages/frosted-ui/README.md
@@ -59,6 +59,16 @@ import { Theme, Tooltip } from 'frosted-ui';
 
 This is deliberately opt-in rather than built into `Theme`: the provider is only reachable through a Base UI namespace export that bundlers cannot tree-shake, so mounting it unconditionally would add ~34 kB gzipped to apps that never render a tooltip.
 
+### Emoji colors
+
+`getColorForEmoji` and `emojiColorMap` live on their own subpath rather than the package root, because the generated lookup table is ~40 kB:
+
+```tsx
+import { getColorForEmoji } from 'frosted-ui/helpers/emoji-colors';
+
+const color = getColorForEmoji('❤️') ?? 'gray';
+```
+
 ## Guides
 
 - [Setup steps](https://storybook.whop.dev/?path=/docs/guides-1-getting-started--docs)

--- a/packages/frosted-ui/package.json
+++ b/packages/frosted-ui/package.json
@@ -38,6 +38,16 @@
       }
     }
   },
+  "typesVersions": {
+    "*": {
+      "helpers/*": [
+        "./dist/cjs/helpers/*.d.ts"
+      ],
+      "components/*": [
+        "./dist/cjs/components/*.d.ts"
+      ]
+    }
+  },
   "sideEffects": false,
   "license": "MIT",
   "files": [

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -69,8 +69,9 @@ export const WithProvider: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
       <Text render={<div />} style={{ maxWidth: 400, textAlign: 'center' }}>
-        Wrap tooltips in <Code>Tooltip.Provider</Code> for shared delay behavior. After hovering one tooltip, subsequent
-        tooltips in the group open instantly.
+        Mount <Code>Tooltip.Provider</Code> once at your app root, alongside <Code>Theme</Code>, so adjacent tooltips
+        share a delay group: after hovering one tooltip, moving to another opens it instantly. It is opt-in so apps that
+        never render a tooltip don&apos;t pay for the module.
       </Text>
 
       <Tooltip.Provider>

--- a/packages/frosted-ui/src/helpers/index.ts
+++ b/packages/frosted-ui/src/helpers/index.ts
@@ -1,6 +1,11 @@
 export * from './breakpoints';
 export * from './compose-event-handlers';
-export * from './emoji-colors';
+// `emojiColorMap` and `getColorForEmoji` are deliberately not re-exported: the
+// generated map is ~40 kB with no internal consumer, so re-exporting it here
+// would pull it into every barrel import. Import them from
+// `frosted-ui/helpers/emoji-colors` instead. The type is erased at build time,
+// so it stays available here for free.
+export type { ColorScale } from './emoji-colors';
 export * from './extract-props-for-tag';
 export * from './get-initials';
 export * from './get-subtree';

--- a/packages/frosted-ui/src/theme.tsx
+++ b/packages/frosted-ui/src/theme.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { DirectionProvider, mergeProps, useRender } from '@base-ui/react';
-import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import classNames from 'classnames';
 import * as React from 'react';
 import { getMatchingGrayColor, themePropDefs } from './theme-options';
@@ -40,12 +39,14 @@ const Theme = (props: ThemeProps) => {
   const context = React.useContext(ThemeContext);
   const isRoot = context === undefined;
   if (isRoot) {
+    // Deliberately no `Tooltip.Provider` here: it would make every consumer of
+    // `Theme` pay for the whole Base UI tooltip module, which is only reachable
+    // through a namespace re-export that bundlers cannot tree-shake. Shared
+    // delay grouping stays opt-in via `Tooltip.Provider`.
     return (
-      <TooltipPrimitive.Provider>
-        <DirectionProvider direction="ltr">
-          <ThemeRoot {...props} />
-        </DirectionProvider>
-      </TooltipPrimitive.Provider>
+      <DirectionProvider direction="ltr">
+        <ThemeRoot {...props} />
+      </DirectionProvider>
     );
   }
   return <ThemeImpl {...props} />;


### PR DESCRIPTION
Two independent tree-shaking fixes. Both are cases where something small was reachable only through a re-export that bundlers cannot shake, so every consumer paid for a whole module they never used.

## Impact

Minified + gzipped, bundled with esbuild against `dist/esm`, React external. Each row is a synthetic app that imports only that entry point.

| What a consumer imports | Before | After | Change |
| --- | --- | --- | --- |
| `Theme` (mandatory root provider) | 36.2 kB | 5.2 kB | **−31.0 kB (−86%)** |
| `Theme` + `Button` | 37.9 kB | 7.2 kB | −30.7 kB (−81%) |
| `Lightbox` | 46.1 kB | 15.4 kB | −30.7 kB (−67%) |
| `Dialog` | 47.0 kB | 26.4 kB | −20.6 kB (−44%) |
| `Sheet` | 55.1 kB | 34.5 kB | −20.6 kB (−37%) |
| `Toaster` | 48.5 kB | 33.3 kB | −15.2 kB (−31%) |
| `Calendar` | 95.9 kB | 83.4 kB | −12.5 kB (−13%) |
| `helpers` barrel | 8.8 kB | 1.8 kB | −7.0 kB (−80%) |
| root barrel, all exports (ESM) | 278.1 kB | 270.4 kB | −7.7 kB (−2.8%) |
| root entry (CJS) | 606.8 kB | 598.9 kB | −7.9 kB (−1.3%) |
| `Tooltip` | 36.9 kB | 36.9 kB | unchanged |

The headline is the first row: `Theme` is mandatory, so **every** app using Frosted UI was carrying ~31 kB gzipped it had no way to opt out of. The savings cascade to the 14 components that import `Theme` internally, and tooltip users lose nothing.

## What changed

### 1. `Theme` no longer mounts `Tooltip.Provider`

`Theme` wrapped its root in Base UI's `Tooltip.Provider`. The provider itself is only ~0.8 kB, but it is reachable exclusively through `export * as Tooltip` — a namespace re-export bundlers cannot tree-shake — so referencing it pulled in the entire tooltip module (trigger, positioner, popup, Floating UI) for 33.8 kB gzipped, whether or not the app ever rendered a tooltip.

**Delays are unchanged.** `Tooltip` always passes `delay` explicitly and Base UI resolves `delay ?? providerDelay ?? OPEN_DELAY`, so the provider was never supplying it. The provider is optional by design — `FloatingDelayGroupContext` defaults to `hasProvider: false`.

The one behaviour change is that **shared delay grouping is now opt-in**: adjacent tooltips opening instantly after the first one requires mounting `Tooltip.Provider` yourself. It was already exported, and already how the component's own story documented it.

```tsx
import { Theme, Tooltip } from 'frosted-ui';

<Tooltip.Provider>
  <Theme>
    <MyApp />
  </Theme>
</Tooltip.Provider>;
```

Storybook's preview and the README now mount it at the root so both reflect the recommended app setup.

### 2. `emojiColorMap` moved off the helpers barrel

`emoji-colors.ts` is a generated 40 kB lookup table for 1,864 emoji with no internal consumer, but the helpers barrel re-exported it, so it rode along with any barrel import.

`getColorForEmoji` and `emojiColorMap` now come from their own subpath, which the existing `./*` exports wildcard already resolved:

```tsx
import { getColorForEmoji } from 'frosted-ui/helpers/emoji-colors';
```

The `ColorScale` type is still re-exported from the barrel as a type-only export, so it stays importable from the package root and, being erased at build time, costs nothing.

This also adds a `typesVersions` map for `helpers/*` and `components/*`. TypeScript's legacy `moduleResolution: node` ignores `exports` entirely, so subpath imports would otherwise fail to typecheck for consumers who have not migrated — as the `tailwind` playground app demonstrated. It is scoped to those two directories rather than a bare `*` wildcard, because a top-level wildcard also captures the package root specifier and breaks `import { ... } from 'frosted-ui'`.

## Migration

| | |
| --- | --- |
| Want grouped tooltip delays | Mount `Tooltip.Provider` at your app root (snippet above). Individual tooltips work unchanged without it. |
| Import `getColorForEmoji` / `emojiColorMap` | Change the specifier to `frosted-ui/helpers/emoji-colors`. |

## Verification

- Before/after measured with the same harness, rebuilding `dist` from each tree, so the deltas are apples-to-apples.
- `Tooltip` measuring identical before and after confirms tooltip consumers are unaffected.
- Lint, typecheck and the full test suite (312 tests) pass; the `tailwind` playground app typechecks against the new subpath.
